### PR TITLE
Simpler download command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Download the script with below command
 
 
 ````
-wget -qO - https://github.com/PRATAP-KUMAR/ubuntu-gdm-set-background/archive/main.tar.gz | tar zx --strip-components=1 ubuntu-gdm-set-background-main/ubuntu-gdm-set-background
+wget -q https://raw.githubusercontent.com/PRATAP-KUMAR/ubuntu-gdm-set-background/main/ubuntu-gdm-set-background && chmod +x ubuntu-gdm-set-background
 ````
 
 there are four options


### PR DESCRIPTION
Hi - nice script!

I wondered if it was worth changing the download command in README.md?

This suggested replacement:

 - Is slightly shorter
 - Downloads fewer bytes (and would download far fewer if getting a script from within a larger repo, ofc)
 - Is easier to read, maybe?

Thanks!