### PR TITLE
fix: Corrected the section that identifies whether the Linux system i…

### DIFF
--- a/ubuntu-gdm-set-background
+++ b/ubuntu-gdm-set-background
@@ -20,15 +20,15 @@ RCol='\e[0m'  # Kept color names as requested
 codename="$(grep UBUNTU_CODENAME /etc/os-release | cut -d = -f 2)"
 osname="$(grep -E '="?Ubuntu"?$' /etc/os-release | cut -d = -f 2)"
 
-if [[ "$codename" =~ ^(focal|hirsute|impish|jammy|kinetic)$ && "$osname" == "Ubuntu" ]]; then  # Changed the condition for better readability
+if [[ "$codename" =~ ^(focal|hirsute|impish|jammy|kinetic)$ && $osname == \"Ubuntu\" ]]; then  # Changed the condition for better readability
   bash src/pre-23.sh "$@"  # Changed to use double quotes for consistency
 fi
 
-if [[ "$codename" =~ ^(lunar|mantic)$ && "$osname" == "Ubuntu" ]]; then
+if [[ "$codename" =~ ^(lunar|mantic)$ && $osname == \"Ubuntu\" ]]; then
   bash src/post-23.sh "$@"  # Changed to use double quotes for consistency
 fi
 
-if [[ "$codename" =~ ^(focal|hirsute|impish|jammy|kinetic|lunar|mantic)$ && "$osname" == "Ubuntu" ]]; then  # Changed the condition for better readability
+if [[ "$codename" =~ ^(focal|hirsute|impish|jammy|kinetic|lunar|mantic)$ && $osname == \"Ubuntu\" ]]; then  # Changed the condition for better readability
 : #no-op cmd, thanks to https://stackoverflow.com/a/17583599
 else
   echo -e "${Red}


### PR DESCRIPTION
I'm using Ubuntu 22.04 and I received the error in the screenshot. I corrected the section that identifies whether the Linux system is Ubuntu and which version of the system. There was a difference in the value of $osname and Ubuntu, and it was necessary to adapt the checker section

![Screenshot from 2023-12-29 17-19-25](https://github.com/PRATAP-KUMAR/ubuntu-gdm-set-background/assets/119333088/6e19a367-8b86-46d3-bc68-aa42a3ee3b42)
