### PR TITLE
Remove BOM character and improve shebang

### DIFF
--- a/ubuntu-gdm-set-background.sh
+++ b/ubuntu-gdm-set-background.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Colors

--- a/ubuntu-gdm-set-background.sh
+++ b/ubuntu-gdm-set-background.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -e
 
 # Colors


### PR DESCRIPTION
- Remove BOM character, which was causing syntax error, preventing the script from running (got this issue on my Ubuntu 20.04.6).
- Improve shebang for OS compatibility (on my system, bash is located at `/usr/bin/bash` instead of `/bin/bash`).
